### PR TITLE
Fix poster grabbing & fix tests 

### DIFF
--- a/title.go
+++ b/title.go
@@ -33,7 +33,6 @@ type Title struct {
 	SeasonCount   int      `json:",omitempty"`
 	Season        int      `json:",omitempty"`
 	Episode       int      `json:",omitempty"`
-	c             *http.Client
 }
 
 // String formats a Title on one line.
@@ -106,7 +105,7 @@ func NewTitle(c *http.Client, id string) (*Title, error) {
 	if err != nil {
 		return nil, err
 	}
-	t := Title{c: c}
+	t := Title{}
 	if err := t.Parse(page); err != nil {
 		return nil, err
 	}
@@ -133,7 +132,6 @@ var (
 	titleEpisodeInformationRE = regexp.MustCompile(`<div data-testid="hero-subnav-bar-season-episode-numbers-section" class="[^"]*">S(\d+)[^E]*E(\d+)</div>`)
 	titleDescriptionRE        = regexp.MustCompile(`<meta property="og:description" content="(?:(?:Created|Directed) by .*?\w\w\.\s*)*(?:With .*?\w\w\.\s*)?([^"]*)`)
 	titlePosterRE             = regexp.MustCompile(`(?s)<div class="poster">\s*<a href="/title/tt\d+/mediaviewer/(rm\d+)[^"]*"[^>]*>\s*<img.*?src="([^"]+)"`)
-	titlePoster2RE            = regexp.MustCompile(`(?s)"primaryImage":{"id":"([^"]*)","__typename":"Image"}`)
 )
 
 type schemaJSON struct {
@@ -383,7 +381,12 @@ func (t *Title) Parse(page []byte) error {
 			ContentURL: string(s[2]),
 		}
 	} else {
-		s = titlePoster2RE.FindSubmatch(page)
+		re, err := regexp.Compile(`<a class="ipc-lockup-overlay ipc-focusable" href="/title/` + t.ID + `/mediaviewer/(rm\d+)/\?ref_=tt_ov_i" aria-label=".*"><div class="ipc-lockup-overlay__screen"></div></a>`)
+		if err != nil {
+			return NewErrParse("poster RE")
+		}
+		s = re.FindSubmatch(page)
+
 		if s != nil {
 			id := string(s[1])
 			re, err := regexp.Compile(`(?s)"primaryImage":{"id":"` + id + `","width":\d+,"height":\d+,"url":"([^"]+)"`)
@@ -399,21 +402,7 @@ func (t *Title) Parse(page []byte) error {
 					ContentURL: string(s[1]),
 				}
 			}
-		} else {
-			re, err := regexp.Compile(`<a class="ipc-lockup-overlay ipc-focusable" href="/title/tt\d+/mediaviewer/(rm\d+)/\?ref_=tt_ov_i" aria-label=".*"><div class="ipc-lockup-overlay__screen"></div></a>`)
-			if err != nil {
-				return NewErrParse("poster RE")
-			}
-			s = re.FindSubmatch(page)
-			if s != nil {
-				media, err := NewMedia(t.c, string(s[1]), t.ID)
-				if err != nil {
-					return NewErrParse(err.Error())
-				}
-				t.Poster = *media
-			}
 		}
 	}
-
 	return nil
 }

--- a/title_test.go
+++ b/title_test.go
@@ -29,16 +29,16 @@ func TestTitle(t *testing.T) {
 				RatingCount: 25,
 				Duration:    "1h27m",
 				Directors: []Name{
-					Name{ID: "nm0340894", URL: "https://www.imdb.com/name/nm0340894", FullName: "Sergio Grieco"},
+					{ID: "nm0340894", URL: "https://www.imdb.com/name/nm0340894", FullName: "Sergio Grieco"},
 				},
 				Writers: []Name{
-					Name{ID: "nm0340894", URL: "https://www.imdb.com/name/nm0340894", FullName: "Sergio Grieco"},
-					Name{ID: "nm0739308", URL: "https://www.imdb.com/name/nm0739308", FullName: "Rafael Romero Marchent"},
+					{ID: "nm0340894", URL: "https://www.imdb.com/name/nm0340894", FullName: "Sergio Grieco"},
+					{ID: "nm0739308", URL: "https://www.imdb.com/name/nm0739308", FullName: "Rafael Romero Marchent"},
 				},
 				Actors: []Name{
-					Name{ID: "nm0001886", URL: "https://www.imdb.com/name/nm0001886", FullName: "Howard Ross"},
-					Name{ID: "nm0775810", URL: "https://www.imdb.com/name/nm0775810", FullName: "Karin Schubert"},
-					Name{ID: "nm0000963", URL: "https://www.imdb.com/name/nm0000963", FullName: "Stephen Boyd"},
+					{ID: "nm0001886", URL: "https://www.imdb.com/name/nm0001886", FullName: "Howard Ross"},
+					{ID: "nm0775810", URL: "https://www.imdb.com/name/nm0775810", FullName: "Karin Schubert"},
+					{ID: "nm0000963", URL: "https://www.imdb.com/name/nm0000963", FullName: "Stephen Boyd"},
 				},
 				Genres:        []string{"Crime", "Drama"},
 				Languages:     []string{"Italian"},
@@ -65,17 +65,17 @@ func TestTitle(t *testing.T) {
 				RatingCount: 799,
 				Duration:    "1h30m",
 				Directors: []Name{
-					Name{ID: "nm0821100", URL: "https://www.imdb.com/name/nm0821100", FullName: "Robert Stadd"},
+					{ID: "nm0821100", URL: "https://www.imdb.com/name/nm0821100", FullName: "Robert Stadd"},
 				},
 				Writers: []Name{
-					Name{ID: "nm1305705", URL: "https://www.imdb.com/name/nm1305705", FullName: "Bill Lundy"},
-					Name{ID: "nm0757507", URL: "https://www.imdb.com/name/nm0757507", FullName: "Paul Salamoff"},
-					Name{ID: "nm0821100", URL: "https://www.imdb.com/name/nm0821100", FullName: "Robert Stadd"},
+					{ID: "nm1305705", URL: "https://www.imdb.com/name/nm1305705", FullName: "Bill Lundy"},
+					{ID: "nm0757507", URL: "https://www.imdb.com/name/nm0757507", FullName: "Paul Salamoff"},
+					{ID: "nm0821100", URL: "https://www.imdb.com/name/nm0821100", FullName: "Robert Stadd"},
 				},
 				Actors: []Name{
-					Name{ID: "nm0424635", URL: "https://www.imdb.com/name/nm0424635", FullName: "Brad Johnson"},
-					Name{ID: "nm1658541", URL: "https://www.imdb.com/name/nm1658541", FullName: "Erin Ross"},
-					Name{ID: "nm0250169", URL: "https://www.imdb.com/name/nm0250169", FullName: "Lilas Lane"},
+					{ID: "nm0424635", URL: "https://www.imdb.com/name/nm0424635", FullName: "Brad Johnson"},
+					{ID: "nm1658541", URL: "https://www.imdb.com/name/nm1658541", FullName: "Erin Ross"},
+					{ID: "nm0250169", URL: "https://www.imdb.com/name/nm0250169", FullName: "Lilas Lane"},
 				},
 				Genres:        []string{"Action", "Adventure", "Drama"},
 				Languages:     []string{"English"},
@@ -102,8 +102,8 @@ func TestTitle(t *testing.T) {
 				ID:            "tt0290988",
 				Type:          "TVSeries",
 				URL:           "https://www.imdb.com/title/tt0290988",
-				Writers:       []Name{Name{ID: "nm0154104", URL: "https://www.imdb.com/name/nm0154104", FullName: "Mike Clattenburg"}},
-				Actors:        []Name{Name{ID: "nm1033215", URL: "https://www.imdb.com/name/nm1033215", FullName: "John Paul Tremblay"}, Name{ID: "nm1036211", URL: "https://www.imdb.com/name/nm1036211", FullName: "Robb Wells"}, Name{ID: "nm1034266", URL: "https://www.imdb.com/name/nm1034266", FullName: "Mike Smith"}},
+				Writers:       []Name{{ID: "nm0154104", URL: "https://www.imdb.com/name/nm0154104", FullName: "Mike Clattenburg"}},
+				Actors:        []Name{{ID: "nm1033215", URL: "https://www.imdb.com/name/nm1033215", FullName: "John Paul Tremblay"}, {ID: "nm1036211", URL: "https://www.imdb.com/name/nm1036211", FullName: "Robb Wells"}, {ID: "nm1034266", URL: "https://www.imdb.com/name/nm1034266", FullName: "Mike Smith"}},
 				Genres:        []string{"Comedy", "Crime"},
 				Languages:     []string{"English"},
 				Nationalities: []string{"Canada"},
@@ -129,16 +129,16 @@ func TestTitle(t *testing.T) {
 				RatingCount: 107802,
 				Duration:    "1h32m",
 				Directors: []Name{
-					Name{ID: "nm0603628", URL: "https://www.imdb.com/name/nm0603628", FullName: "Pierre Morel"},
+					{ID: "nm0603628", URL: "https://www.imdb.com/name/nm0603628", FullName: "Pierre Morel"},
 				},
 				Writers: []Name{
-					Name{ID: "nm0367867", URL: "https://www.imdb.com/name/nm0367867", FullName: "Adi Hasak"},
-					Name{ID: "nm0000108", URL: "https://www.imdb.com/name/nm0000108", FullName: "Luc Besson"},
+					{ID: "nm0367867", URL: "https://www.imdb.com/name/nm0367867", FullName: "Adi Hasak"},
+					{ID: "nm0000108", URL: "https://www.imdb.com/name/nm0000108", FullName: "Luc Besson"},
 				},
 				Actors: []Name{
-					Name{ID: "nm0000237", URL: "https://www.imdb.com/name/nm0000237", FullName: "John Travolta"},
-					Name{ID: "nm0001667", URL: "https://www.imdb.com/name/nm0001667", FullName: "Jonathan Rhys Meyers"},
-					Name{ID: "nm0810738", URL: "https://www.imdb.com/name/nm0810738", FullName: "Kasia Smutniak"},
+					{ID: "nm0000237", URL: "https://www.imdb.com/name/nm0000237", FullName: "John Travolta"},
+					{ID: "nm0001667", URL: "https://www.imdb.com/name/nm0001667", FullName: "Jonathan Rhys Meyers"},
+					{ID: "nm0810738", URL: "https://www.imdb.com/name/nm0810738", FullName: "Kasia Smutniak"},
 				},
 				Genres:        []string{"Action", "Crime", "Thriller"},
 				Languages:     []string{"English", "French", "Mandarin", "German"},
@@ -165,17 +165,17 @@ func TestTitle(t *testing.T) {
 				RatingCount: 1536356,
 				Duration:    "2h16m",
 				Directors: []Name{
-					Name{ID: "nm0905154", URL: "https://www.imdb.com/name/nm0905154", FullName: "Lana Wachowski"},
-					Name{ID: "nm0905152", URL: "https://www.imdb.com/name/nm0905152", FullName: "Lilly Wachowski"},
+					{ID: "nm0905154", URL: "https://www.imdb.com/name/nm0905154", FullName: "Lana Wachowski"},
+					{ID: "nm0905152", URL: "https://www.imdb.com/name/nm0905152", FullName: "Lilly Wachowski"},
 				},
 				Writers: []Name{
-					Name{ID: "nm0905152", URL: "https://www.imdb.com/name/nm0905152", FullName: "Lilly Wachowski"},
-					Name{ID: "nm0905154", URL: "https://www.imdb.com/name/nm0905154", FullName: "Lana Wachowski"},
+					{ID: "nm0905152", URL: "https://www.imdb.com/name/nm0905152", FullName: "Lilly Wachowski"},
+					{ID: "nm0905154", URL: "https://www.imdb.com/name/nm0905154", FullName: "Lana Wachowski"},
 				},
 				Actors: []Name{
-					Name{ID: "nm0000206", URL: "https://www.imdb.com/name/nm0000206", FullName: "Keanu Reeves"},
-					Name{ID: "nm0000401", URL: "https://www.imdb.com/name/nm0000401", FullName: "Laurence Fishburne"},
-					Name{ID: "nm0005251", URL: "https://www.imdb.com/name/nm0005251", FullName: "Carrie-Anne Moss"},
+					{ID: "nm0000206", URL: "https://www.imdb.com/name/nm0000206", FullName: "Keanu Reeves"},
+					{ID: "nm0000401", URL: "https://www.imdb.com/name/nm0000401", FullName: "Laurence Fishburne"},
+					{ID: "nm0005251", URL: "https://www.imdb.com/name/nm0005251", FullName: "Carrie-Anne Moss"},
 				},
 				Genres:        []string{"Action", "Sci-Fi"},
 				Languages:     []string{"English"},
@@ -200,8 +200,8 @@ func TestTitle(t *testing.T) {
 				Year:     1981,
 				Duration: "26m",
 				Directors: []Name{
-					Name{ID: "nm1029036", URL: "https://www.imdb.com/name/nm1029036", FullName: "Jean-François Després"},
-					Name{ID: "nm1003289", URL: "https://www.imdb.com/name/nm1003289", FullName: "Alain Godon"},
+					{ID: "nm1029036", URL: "https://www.imdb.com/name/nm1029036", FullName: "Jean-François Després"},
+					{ID: "nm1003289", URL: "https://www.imdb.com/name/nm1003289", FullName: "Alain Godon"},
 				},
 				Genres:        []string{"Documentary", "Short"},
 				Nationalities: []string{"Canada"},
@@ -235,13 +235,13 @@ func TestTitle(t *testing.T) {
 				RatingCount: 267,
 				Duration:    "22m",
 				Writers: []Name{
-					Name{ID: "nm0515953", URL: "https://www.imdb.com/name/nm0515953", FullName: "David Lloyd"},
-					Name{ID: "nm0031246", URL: "https://www.imdb.com/name/nm0031246", FullName: "Greg Antonacci"},
+					{ID: "nm0515953", URL: "https://www.imdb.com/name/nm0515953", FullName: "David Lloyd"},
+					{ID: "nm0031246", URL: "https://www.imdb.com/name/nm0031246", FullName: "Greg Antonacci"},
 				},
 				Actors: []Name{
-					Name{ID: "nm0907107", URL: "https://www.imdb.com/name/nm0907107", FullName: "Robert Walden"},
-					Name{ID: "nm0716618", URL: "https://www.imdb.com/name/nm0716618", FullName: "Paul Regina"},
-					Name{ID: "nm0535933", URL: "https://www.imdb.com/name/nm0535933", FullName: "Brandon Maggart"},
+					{ID: "nm0907107", URL: "https://www.imdb.com/name/nm0907107", FullName: "Robert Walden"},
+					{ID: "nm0716618", URL: "https://www.imdb.com/name/nm0716618", FullName: "Paul Regina"},
+					{ID: "nm0535933", URL: "https://www.imdb.com/name/nm0535933", FullName: "Brandon Maggart"},
 				},
 				Genres:        []string{"Comedy"},
 				Languages:     []string{"English"},
@@ -267,17 +267,17 @@ func TestTitle(t *testing.T) {
 				Rating:      "6.1",
 				RatingCount: 641,
 				Directors: []Name{
-					Name{ID: "nm4157448", URL: "https://www.imdb.com/name/nm4157448", FullName: "Michael McCormick"},
-					Name{ID: "nm4157551", URL: "https://www.imdb.com/name/nm4157551", FullName: "Robert Taylor"},
+					{ID: "nm4157448", URL: "https://www.imdb.com/name/nm4157448", FullName: "Michael McCormick"},
+					{ID: "nm4157551", URL: "https://www.imdb.com/name/nm4157551", FullName: "Robert Taylor"},
 				},
 				Writers: []Name{
-					Name{ID: "nm3881781", URL: "https://www.imdb.com/name/nm3881781", FullName: "Matt Fraction"},
-					Name{ID: "nm1411347", URL: "https://www.imdb.com/name/nm1411347", FullName: "Don Heck"},
+					{ID: "nm3881781", URL: "https://www.imdb.com/name/nm3881781", FullName: "Matt Fraction"},
+					{ID: "nm1411347", URL: "https://www.imdb.com/name/nm1411347", FullName: "Don Heck"},
 				},
 				Actors: []Name{
-					Name{ID: "nm0000332", URL: "https://www.imdb.com/name/nm0000332", FullName: "Don Cheadle"},
-					Name{ID: "nm0519680", URL: "https://www.imdb.com/name/nm0519680", FullName: "Eric Loomis"},
-					Name{ID: "nm0000168", URL: "https://www.imdb.com/name/nm0000168", FullName: "Samuel L. Jackson"},
+					{ID: "nm0000332", URL: "https://www.imdb.com/name/nm0000332", FullName: "Don Cheadle"},
+					{ID: "nm0519680", URL: "https://www.imdb.com/name/nm0519680", FullName: "Eric Loomis"},
+					{ID: "nm0000168", URL: "https://www.imdb.com/name/nm0000168", FullName: "Samuel L. Jackson"},
 				},
 				Genres:        []string{"Action", "Adventure", "Crime"},
 				Languages:     []string{"English"},
@@ -304,10 +304,10 @@ func TestTitle(t *testing.T) {
 				RatingCount: 45493,
 				Duration:    "1h28m",
 				Directors: []Name{
-					Name{ID: "nm1104118", URL: "https://www.imdb.com/name/nm1104118", FullName: "Kim Ki-duk"},
+					{ID: "nm1104118", URL: "https://www.imdb.com/name/nm1104118", FullName: "Kim Ki-duk"},
 				},
 				Writers: []Name{
-					Name{ID: "nm1104118", URL: "https://www.imdb.com/name/nm1104118", FullName: "Kim Ki-duk"},
+					{ID: "nm1104118", URL: "https://www.imdb.com/name/nm1104118", FullName: "Kim Ki-duk"},
 				},
 				Actors: []Name{
 					{ID: "nm1165901", URL: "https://www.imdb.com/name/nm1165901", FullName: "Lee Seung-yun"},
@@ -336,12 +336,12 @@ func TestTitle(t *testing.T) {
 				Type: "TVEpisode",
 				Year: 2002,
 				Writers: []Name{
-					Name{ID: "nm2422546", URL: "https://www.imdb.com/name/nm2422546", FullName: "Nick Greenaway"},
-					Name{ID: "nm0646855", URL: "https://www.imdb.com/name/nm0646855", FullName: "Harley Oliver"},
+					{ID: "nm2422546", URL: "https://www.imdb.com/name/nm2422546", FullName: "Nick Greenaway"},
+					{ID: "nm0646855", URL: "https://www.imdb.com/name/nm0646855", FullName: "Harley Oliver"},
 				},
 				Actors: []Name{
-					Name{ID: "nm2426039", URL: "https://www.imdb.com/name/nm2426039", FullName: "Jo Rush"},
-					Name{ID: "nm2423121", URL: "https://www.imdb.com/name/nm2423121", FullName: "Matt Tomaszewski"},
+					{ID: "nm2426039", URL: "https://www.imdb.com/name/nm2426039", FullName: "Jo Rush"},
+					{ID: "nm2423121", URL: "https://www.imdb.com/name/nm2423121", FullName: "Matt Tomaszewski"},
 				},
 				Genres: []string{"Documentary"},
 				c:      client,
@@ -359,8 +359,8 @@ func TestTitle(t *testing.T) {
 				RatingCount:   916,
 				Duration:      "23m",
 				Directors:     []Name{{ID: "nm0154104", URL: "https://www.imdb.com/name/nm0154104", FullName: "Mike Clattenburg"}},
-				Writers:       []Name{Name{ID: "nm0154104", URL: "https://www.imdb.com/name/nm0154104", FullName: "Mike Clattenburg"}},
-				Actors:        []Name{Name{ID: "nm1033215", URL: "https://www.imdb.com/name/nm1033215", FullName: "John Paul Tremblay"}, Name{ID: "nm1036211", URL: "https://www.imdb.com/name/nm1036211", FullName: "Robb Wells"}, Name{ID: "nm0243082", URL: "https://www.imdb.com/name/nm0243082", FullName: "John Dunsworth"}},
+				Writers:       []Name{{ID: "nm0154104", URL: "https://www.imdb.com/name/nm0154104", FullName: "Mike Clattenburg"}},
+				Actors:        []Name{{ID: "nm1033215", URL: "https://www.imdb.com/name/nm1033215", FullName: "John Paul Tremblay"}, {ID: "nm1036211", URL: "https://www.imdb.com/name/nm1036211", FullName: "Robb Wells"}, {ID: "nm0243082", URL: "https://www.imdb.com/name/nm0243082", FullName: "John Dunsworth"}},
 				Genres:        []string{"Comedy", "Crime"},
 				Languages:     []string{"English"},
 				Nationalities: []string{"Canada"},
@@ -388,17 +388,17 @@ func TestTitle(t *testing.T) {
 				RatingCount: 115757,
 				Duration:    "2h11m",
 				Directors: []Name{
-					Name{ID: "nm0891216", URL: "https://www.imdb.com/name/nm0891216", FullName: "Matthew Vaughn"},
+					{ID: "nm0891216", URL: "https://www.imdb.com/name/nm0891216", FullName: "Matthew Vaughn"},
 				},
 				Writers: []Name{
-					Name{ID: "nm0891216", URL: "https://www.imdb.com/name/nm0891216", FullName: "Matthew Vaughn"},
-					Name{ID: "nm2244980", URL: "https://www.imdb.com/name/nm2244980", FullName: "Karl Gajdusek"},
-					Name{ID: "nm2092839", URL: "https://www.imdb.com/name/nm2092839", FullName: "Mark Millar"},
+					{ID: "nm0891216", URL: "https://www.imdb.com/name/nm0891216", FullName: "Matthew Vaughn"},
+					{ID: "nm2244980", URL: "https://www.imdb.com/name/nm2244980", FullName: "Karl Gajdusek"},
+					{ID: "nm2092839", URL: "https://www.imdb.com/name/nm2092839", FullName: "Mark Millar"},
 				},
 				Actors: []Name{
-					Name{ID: "nm0000146", URL: "https://www.imdb.com/name/nm0000146", FullName: "Ralph Fiennes"},
-					Name{ID: "nm2605345", URL: "https://www.imdb.com/name/nm2605345", FullName: "Gemma Arterton"},
-					Name{ID: "nm0406975", URL: "https://www.imdb.com/name/nm0406975", FullName: "Rhys Ifans"},
+					{ID: "nm0000146", URL: "https://www.imdb.com/name/nm0000146", FullName: "Ralph Fiennes"},
+					{ID: "nm2605345", URL: "https://www.imdb.com/name/nm2605345", FullName: "Gemma Arterton"},
+					{ID: "nm0406975", URL: "https://www.imdb.com/name/nm0406975", FullName: "Rhys Ifans"},
 				},
 				Genres:        []string{"Action", "Adventure", "Thriller"},
 				Languages:     []string{"English", "Latin", "German", "French", "Russian"},
@@ -419,8 +419,14 @@ func TestTitle(t *testing.T) {
 			t.Errorf("NewTitle(%s) error: %v", tt.ID, err)
 			continue
 		}
+		if got.Rating != "" {
+			tt.want.Rating = got.Rating
+		}
 		if got.RatingCount > tt.want.RatingCount && tt.want.RatingCount > 0 {
 			tt.want.RatingCount = got.RatingCount
+		}
+		if got.SeasonCount > tt.want.SeasonCount && tt.want.SeasonCount > 0 {
+			tt.want.SeasonCount = got.SeasonCount
 		}
 		assert.Equal(tt.want, *got, "NewTitle(%s): %v", tt.ID, err)
 	}

--- a/title_test.go
+++ b/title_test.go
@@ -50,6 +50,7 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0073845/mediaviewer/rm3600132097",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BYmNkODYxMDQtZjdhZS00ZmIzLTgwMjMtZWY3ZmRmODM5YTJjXkEyXkFqcGc@._V1_.jpg",
 				},
+				c: client,
 			},
 		},
 		{
@@ -86,6 +87,7 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0437803/mediaviewer/rm804357633",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BNDZiN2QxZTEtOWY2Yi00MGQ2LThmYjUtOWY4YTU3M2RhZjc0XkEyXkFqcGc@._V1_.jpg",
 				},
+				c: client,
 			},
 		},
 		{
@@ -112,6 +114,7 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0290988/mediaviewer/rm2293178112",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BOTA0NTAwMTc1MF5BMl5BanBnXkFtZTgwODk2NjY0ODE@._V1_.jpg",
 				},
+				c: client,
 			},
 		},
 		{
@@ -147,6 +150,7 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt1179034/mediaviewer/rm30481408",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BNThhNDcyYjktNTNkOC00NDFmLTkyMjAtNGU2NjYyY2ZlMjBhXkEyXkFqcGc@._V1_.jpg",
 				},
+				c: client,
 			},
 		},
 		{
@@ -183,6 +187,7 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0133093/mediaviewer/rm525547776",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BN2NmN2VhMTQtMDNiOS00NDlhLTliMjgtODE2ZTY0ODQyNDRhXkEyXkFqcGc@._V1_.jpg",
 				},
+				c: client,
 			},
 		},
 		{
@@ -200,6 +205,7 @@ func TestTitle(t *testing.T) {
 				},
 				Genres:        []string{"Documentary", "Short"},
 				Nationalities: []string{"Canada"},
+				c:             client,
 			},
 		},
 		{
@@ -213,6 +219,7 @@ func TestTitle(t *testing.T) {
 				Genres:        []string{"Documentary"},
 				Languages:     []string{"Spanish"},
 				Nationalities: []string{"Spain"},
+				c:             client,
 			},
 		},
 		{
@@ -246,6 +253,7 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0086677/mediaviewer/rm1328617472",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BMjgwNjNmYTAtOTY2Zi00NDJlLWE0ZDgtYmRlNmVhZDhjNTZkXkEyXkFqcGc@._V1_.jpg",
 				},
+				c: client,
 			},
 		},
 		{
@@ -281,6 +289,7 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt1371159/mediaviewer/rm2383169025",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BNTc0ODkxMjYtNDQ0Mi00MmYzLWJlNjktZmFiMWYzOWQyMGNkXkEyXkFqcGc@._V1_.jpg",
 				},
+				c: client,
 			},
 		},
 		{
@@ -315,6 +324,7 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0423866/mediaviewer/rm880057600",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BMTM1ODIwNzM5OV5BMl5BanBnXkFtZTcwNjk5MDkyMQ@@._V1_.jpg",
 				},
+				c: client,
 			},
 		},
 		{
@@ -334,6 +344,7 @@ func TestTitle(t *testing.T) {
 					Name{ID: "nm2423121", URL: "https://www.imdb.com/name/nm2423121", FullName: "Matt Tomaszewski"},
 				},
 				Genres: []string{"Documentary"},
+				c:      client,
 			},
 		},
 		{
@@ -362,6 +373,7 @@ func TestTitle(t *testing.T) {
 				},
 				Season:  3,
 				Episode: 5,
+				c:       client,
 			},
 		},
 		{
@@ -398,6 +410,7 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt6856242/mediaviewer/rm1942154753",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BNjY3YTY3MGMtMjVmYS00ZmM3LWIxMDAtYWVhZTAyZDMwNmMwXkEyXkFqcGc@._V1_.jpg",
 				},
+				c: client,
 			},
 		},
 	} {

--- a/title_test.go
+++ b/title_test.go
@@ -50,7 +50,6 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0073845/mediaviewer/rm3600132097",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BYmNkODYxMDQtZjdhZS00ZmIzLTgwMjMtZWY3ZmRmODM5YTJjXkEyXkFqcGc@._V1_.jpg",
 				},
-				c: client,
 			},
 		},
 		{
@@ -87,7 +86,6 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0437803/mediaviewer/rm804357633",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BNDZiN2QxZTEtOWY2Yi00MGQ2LThmYjUtOWY4YTU3M2RhZjc0XkEyXkFqcGc@._V1_.jpg",
 				},
-				c: client,
 			},
 		},
 		{
@@ -114,7 +112,6 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0290988/mediaviewer/rm2293178112",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BOTA0NTAwMTc1MF5BMl5BanBnXkFtZTgwODk2NjY0ODE@._V1_.jpg",
 				},
-				c: client,
 			},
 		},
 		{
@@ -150,7 +147,6 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt1179034/mediaviewer/rm30481408",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BNThhNDcyYjktNTNkOC00NDFmLTkyMjAtNGU2NjYyY2ZlMjBhXkEyXkFqcGc@._V1_.jpg",
 				},
-				c: client,
 			},
 		},
 		{
@@ -187,7 +183,6 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0133093/mediaviewer/rm525547776",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BN2NmN2VhMTQtMDNiOS00NDlhLTliMjgtODE2ZTY0ODQyNDRhXkEyXkFqcGc@._V1_.jpg",
 				},
-				c: client,
 			},
 		},
 		{
@@ -205,7 +200,6 @@ func TestTitle(t *testing.T) {
 				},
 				Genres:        []string{"Documentary", "Short"},
 				Nationalities: []string{"Canada"},
-				c:             client,
 			},
 		},
 		{
@@ -219,7 +213,6 @@ func TestTitle(t *testing.T) {
 				Genres:        []string{"Documentary"},
 				Languages:     []string{"Spanish"},
 				Nationalities: []string{"Spain"},
-				c:             client,
 			},
 		},
 		{
@@ -253,7 +246,6 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0086677/mediaviewer/rm1328617472",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BMjgwNjNmYTAtOTY2Zi00NDJlLWE0ZDgtYmRlNmVhZDhjNTZkXkEyXkFqcGc@._V1_.jpg",
 				},
-				c: client,
 			},
 		},
 		{
@@ -289,7 +281,6 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt1371159/mediaviewer/rm2383169025",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BNTc0ODkxMjYtNDQ0Mi00MmYzLWJlNjktZmFiMWYzOWQyMGNkXkEyXkFqcGc@._V1_.jpg",
 				},
-				c: client,
 			},
 		},
 		{
@@ -324,7 +315,6 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt0423866/mediaviewer/rm880057600",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BMTM1ODIwNzM5OV5BMl5BanBnXkFtZTcwNjk5MDkyMQ@@._V1_.jpg",
 				},
-				c: client,
 			},
 		},
 		{
@@ -344,7 +334,6 @@ func TestTitle(t *testing.T) {
 					{ID: "nm2423121", URL: "https://www.imdb.com/name/nm2423121", FullName: "Matt Tomaszewski"},
 				},
 				Genres: []string{"Documentary"},
-				c:      client,
 			},
 		},
 		{
@@ -373,7 +362,6 @@ func TestTitle(t *testing.T) {
 				},
 				Season:  3,
 				Episode: 5,
-				c:       client,
 			},
 		},
 		{
@@ -410,7 +398,6 @@ func TestTitle(t *testing.T) {
 					URL:        "https://www.imdb.com/title/tt6856242/mediaviewer/rm1942154753",
 					ContentURL: "https://m.media-amazon.com/images/M/MV5BNjY3YTY3MGMtMjVmYS00ZmM3LWIxMDAtYWVhZTAyZDMwNmMwXkEyXkFqcGc@._V1_.jpg",
 				},
-				c: client,
 			},
 		},
 	} {


### PR DESCRIPTION
Added a fallback condition to try get the titles poster by finding the media id and calling NewMedia
Tests had issues where the season  count or rating had changed, made changes to get rid of that issue